### PR TITLE
Pattern overlay

### DIFF
--- a/fansi/shared/src/main/scala/fansi/Fansi.scala
+++ b/fansi/shared/src/main/scala/fansi/Fansi.scala
@@ -3,7 +3,6 @@ package fansi
 import java.util
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 /**
   * Encapsulates a string with associated ANSI colors and text decorations.

--- a/fansi/shared/src/main/scala/fansi/Fansi.scala
+++ b/fansi/shared/src/main/scala/fansi/Fansi.scala
@@ -157,6 +157,13 @@ case class Str private(private val chars: Array[Char], private val colors: Array
   }
 
   /**
+    * Overlays the desired color over the specified pattern
+    */
+  def overlay(attrs: Attrs, pattern: String) = {
+    overlayAll(Str.boundsOf(new String(chars), pattern, 0).map(bs => (attrs, bs._1, bs._2)))
+  }
+
+  /**
     * Batch version of [[overlay]], letting you apply a bunch of [[Attrs]] onto
     * various parts of the same string in one operation, avoiding the unnecessary
     * copying that would happen if you applied them with [[overlay]] one by one.
@@ -351,6 +358,14 @@ object Str{
     } yield (str, color)
     new Trie(pairs :+ (Console.RESET -> Attr.Reset))
   }
+
+  private[Str] def boundsOf(string: String, pattern: String, fromIndex: Int): Stream[(Int, Int)] =
+    string.indexOf(pattern, fromIndex) match {
+      case -1 => Stream.empty
+      case from =>
+        val to = from + pattern.length
+        (from, to) #:: boundsOf(string, pattern, to)
+    }
 }
 
 /**

--- a/fansi/shared/src/test/scala/fansi/FansiTests.scala
+++ b/fansi/shared/src/test/scala/fansi/FansiTests.scala
@@ -102,6 +102,26 @@ object FansiTests extends TestSuite{
 
         assert(overlayed == expected)
       }
+      'pattern{
+        val overlayed = fansi.Str(rgbOps).overlay(fansi.Color.Yellow, "--*")
+        val expected = s"+++$R-$Y--*$G**$B///$RTC"
+        assert(overlayed.render == expected)
+      }
+      'missingPattern{
+        val overlayed = fansi.Str(rgbOps).overlay(fansi.Color.Yellow, "+**")
+        val expected = s"$rgbOps$RTC"
+        assert(overlayed.render == expected)
+      }
+      'fullPattern {
+        val overlayed = fansi.Str(rgbOps).overlay(fansi.Color.Yellow, fansi.Str(rgbOps).plainText)
+        val expected = s"$Y+++---***///$RTC"
+        assert(overlayed.render == expected)
+      }
+      'recurringPattern {
+        val overlayed = fansi.Str("^_^").overlay(fansi.Color.Green, "^")
+        val expected = s"$G^${RTC}_$G^${RTC}"
+        assert(overlayed.render == expected)
+      }
       'underlines{
         val resetty = s"$UND#$RES    $UND#$RES"
         'underlineBug{

--- a/fansi/shared/src/test/scala/fansi/FansiTests.scala
+++ b/fansi/shared/src/test/scala/fansi/FansiTests.scala
@@ -24,6 +24,7 @@ object FansiTests extends TestSuite{
   val tests = TestSuite{
     val rgbOps = s"+++$R---$G***$B///"
     val rgb = s"$R$G$B"
+    val text = "would you like to taste a tomato"
     'parsing{
       val r = fansi.Str(rgbOps).render
       assert(
@@ -102,24 +103,39 @@ object FansiTests extends TestSuite{
 
         assert(overlayed == expected)
       }
-      'pattern{
-        val overlayed = fansi.Str(rgbOps).overlay(fansi.Color.Yellow, "--*")
-        val expected = s"+++$R-$Y--*$G**$B///$RTC"
+      'simplePattern{
+        val overlayed = fansi.Str(text).overlay(fansi.Color.Red, "tomato")
+        val expected = s"would you like to taste a ${R}tomato${RTC}"
+        assert(overlayed.render == expected)
+      }
+      'regexPattern{
+        val overlayed = fansi.Str(text).overlay(fansi.Color.Green, "y\\w+")
+        val expected = s"would ${G}you${RTC} like to taste a tomato"
         assert(overlayed.render == expected)
       }
       'missingPattern{
-        val overlayed = fansi.Str(rgbOps).overlay(fansi.Color.Yellow, "+**")
-        val expected = s"$rgbOps$RTC"
+        val overlayed = fansi.Str(text).overlay(fansi.Color.Yellow, "banana")
+        val expected = "would you like to taste a tomato"
         assert(overlayed.render == expected)
       }
-      'fullPattern {
-        val overlayed = fansi.Str(rgbOps).overlay(fansi.Color.Yellow, fansi.Str(rgbOps).plainText)
-        val expected = s"$Y+++---***///$RTC"
+      'fullPattern{
+        val overlayed = fansi.Str(text).overlay(fansi.Color.Red, "would you like to taste a tomato")
+        val expected = s"${R}would you like to taste a tomato${RTC}"
         assert(overlayed.render == expected)
       }
-      'recurringPattern {
-        val overlayed = fansi.Str("^_^").overlay(fansi.Color.Green, "^")
-        val expected = s"$G^${RTC}_$G^${RTC}"
+      'endingPattern{
+        val overlayed = fansi.Str(text).overlay(fansi.Color.Red, "mato")
+        val expected = s"would you like to taste a to${R}mato${RTC}"
+        assert(overlayed.render == expected)
+      }
+      'recurringSimplePattern{
+        val overlayed = fansi.Str(text).overlay(fansi.Color.Red, "to")
+        val expected = s"would you like ${R}to${RTC} taste a ${R}to${RTC}ma${R}to${RTC}"
+        assert(overlayed.render == expected)
+      }
+      'recurringRegexPattern{
+        val overlayed = fansi.Str(text).overlay(fansi.Color.Red, "[t|y]\\w+")
+        val expected = s"would ${R}you${RTC} like ${R}to${RTC} ${R}taste${RTC} a ${R}tomato${RTC}"
         assert(overlayed.render == expected)
       }
       'underlines{


### PR DESCRIPTION
Addresses #3: this PR adds a method to the `fansi.Str` instances to apply an overlay on occurrences of a regular expression in the wrapped sequence of characters.
