### PR TITLE
Add dotty cross compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,4 @@ jdk:
 
 script:
   - curl https://raw.githubusercontent.com/scala-native/scala-native/b7851c4dc2a22c9fd9202aea3d97e2a68910b918/scripts/travis_setup.sh | bash -x
-  # TODO: remove these later
-  - git clone --depth 1 https://github.com/lihaoyi/sourcecode.git
-  - cd sourcecode && ./mill sourcecode.jvm[0.24.0-RC1].publishLocal && cd ..
-  - git clone --depth 1 https://github.com/lihaoyi/utest.git
-  - cd utest && ./mill utest.jvm[0.24.0-RC1].publishLocal && cd ..
   - ./mill -i __.__.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,9 @@ jdk:
 
 script:
   - curl https://raw.githubusercontent.com/scala-native/scala-native/b7851c4dc2a22c9fd9202aea3d97e2a68910b918/scripts/travis_setup.sh | bash -x
+  # TODO: remove these later
+  - git clone --depth 1 https://github.com/lihaoyi/sourcecode.git
+  - cd sourcecode && ./mill sourcecode.jvm[0.24.0-RC1].publishLocal && cd ..
+  - git clone --depth 1 https://github.com/lihaoyi/utest.git
+  - cd utest && ./mill utest.jvm[0.24.0-RC1].publishLocal && cd ..
   - ./mill -i __.__.test

--- a/build.sc
+++ b/build.sc
@@ -70,7 +70,7 @@ object fansi extends Module {
 
   val dottyVersion = Option(sys.props("dottyVersion"))
 
-  object jvm extends Cross[JvmFansiModule]((List("2.12.10", "2.13.1", "0.24.0-RC1") ++ dottyVersion): _*)
+  object jvm extends Cross[JvmFansiModule]((List("2.12.10", "2.13.1", "0.26.0-RC1") ++ dottyVersion): _*)
   class JvmFansiModule(val crossScalaVersion: String)
     extends FansiMainModule with ScalaModule with FansiModule {
     object test extends Tests with FansiTestModule{

--- a/build.sc
+++ b/build.sc
@@ -67,7 +67,10 @@ trait FansiTestModule extends ScalaModule with TestModule {
 }
 
 object fansi extends Module {
-  object jvm extends Cross[JvmFansiModule]("2.12.10", "2.13.1", "0.24.0-RC1")
+
+  val dottyVersion = Option(sys.props("dottyVersion"))
+
+  object jvm extends Cross[JvmFansiModule]((List("2.12.10", "2.13.1", "0.24.0-RC1") ++ dottyVersion): _*)
   class JvmFansiModule(val crossScalaVersion: String)
     extends FansiMainModule with ScalaModule with FansiModule {
     object test extends Tests with FansiTestModule{

--- a/build.sc
+++ b/build.sc
@@ -58,7 +58,7 @@ trait FansiTestModule extends ScalaModule with TestModule {
 }
 
 object fansi extends Module {
-  object jvm extends Cross[JvmFansiModule]("2.12.10", "2.13.1")
+  object jvm extends Cross[JvmFansiModule]("2.12.10", "2.13.1", "0.24.0-RC1")
   class JvmFansiModule(val crossScalaVersion: String)
     extends FansiMainModule with ScalaModule with FansiModule {
     object test extends Tests with FansiTestModule{

--- a/build.sc
+++ b/build.sc
@@ -34,6 +34,15 @@ trait FansiMainModule extends CrossScalaModule {
       )
   )
 
+  override def docJar =
+    if (crossScalaVersion.startsWith("2")) super.docJar
+    else T {
+      val outDir = T.ctx().dest
+      val javadocDir = outDir / 'javadoc
+      os.makeDir.all(javadocDir)
+      mill.api.Result.Success(mill.modules.Jvm.createJar(Agg(javadocDir))(outDir))
+    }
+
 }
 
 


### PR DESCRIPTION
Adding cross compilation for dotty. This requires both `utest` and `sourcecode` to be locally published.

I've added the travis steps - but it seems to be force terminating due to log output.

EDIT:

The above was true on my own fork, this failure seems to be from:

`fansi.native[2.11.12,0.3.9].test.testRunnerNative.nativeLink java.lang.RuntimeException: Failed to compile native library runtime code.`

Relevant log lines for dotty:

```
[471/874] fansi.jvm[0.24.0-RC1].test.unmanagedClasspath 
[472/874] fansi.jvm[0.24.0-RC1].test.scalaVersion 
[473/874] fansi.jvm[0.24.0-RC1].test.platformSuffix 
[474/874] fansi.jvm[0.24.0-RC1].test.compileIvyDeps 
[475/874] fansi.jvm[0.24.0-RC1].test.scalaOrganization 
[476/874] fansi.jvm[0.24.0-RC1].test.scalaLibraryIvyDeps 
[477/874] fansi.jvm[0.24.0-RC1].test.ivyDeps 
[478/874] fansi.jvm[0.24.0-RC1].test.transitiveIvyDeps 
[479/874] fansi.jvm[0.24.0-RC1].test.compileClasspath 
[480/874] fansi.jvm[0.24.0-RC1].test.scalaCompilerClasspath 
[481/874] fansi.jvm[0.24.0-RC1].test.scalacPluginClasspath 
[482/874] fansi.jvm[0.24.0-RC1].test.compile 
[info] Compiling 1 Scala source to /home/travis/build/lihaoyi/fansi/out/fansi/jvm/0.24.0-RC1/test/compile/dest/classes ...
[info] Done compiling.
[483/874] fansi.jvm[0.24.0-RC1].test.localClasspath 
[484/874] fansi.jvm[0.24.0-RC1].test.runIvyDeps 
[485/874] fansi.jvm[0.24.0-RC1].test.upstreamAssemblyClasspath 
[486/874] fansi.jvm[0.24.0-RC1].test.runClasspath 
[487/874] fansi.jvm[0.24.0-RC1].test.forkWorkingDir 
[488/874] fansi.jvm[0.24.0-RC1].test.test 
-------------------------------- Running Tests --------------------------------
+ test.fansi.FansiTests.parsing 151ms  
+ test.fansi.FansiTests.equality 3ms  
+ test.fansi.FansiTests.concat 1ms  
+ test.fansi.FansiTests.join 2ms  
+ test.fansi.FansiTests.get 19ms  
+ test.fansi.FansiTests.split 4ms  
+ test.fansi.FansiTests.substring 11ms  
+ test.fansi.FansiTests.overlay.simple 5ms  
+ test.fansi.FansiTests.overlay.resetty 0ms  
+ test.fansi.FansiTests.overlay.mixedResetUnderline 7ms  
+ test.fansi.FansiTests.overlay.underlines.underlineBug 6ms  
+ test.fansi.FansiTests.overlay.underlines.barelyOverlapping 1ms  
+ test.fansi.FansiTests.overlay.underlines.endOfLine 1ms  
+ test.fansi.FansiTests.overlay.underlines.overshoot 1ms  java.lang.IllegalArgumentException: requirement failed: end:10 must be less than or equal to length:6
+ test.fansi.FansiTests.overlay.underlines.empty 1ms  
+ test.fansi.FansiTests.overlay.underlines.singleContent 1ms  
+ test.fansi.FansiTests.overlay.overallAll 0ms  +++---***///
+ test.fansi.FansiTests.attributes 2ms  Apply(Reset Reversed)
```